### PR TITLE
feat: stabilize session startup via control mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ twig delete [project]    # Delete project config
 twig stop [project]      # Kill tmux session
 
 # Debug tmux control-mode I/O
-TWIG_TMUX_DEBUG=1 twig window new [project] [name]
+Setting `TWIG_DEBUG=1` enables verbose tmux control output on stderr.
+TWIG_DEBUG=1 twig window new [project] [name]
 
 # Run a command in a window/pane
 twig run --project=dotfiles --window=6 --pane=1 -- whoami

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 _.file = { path = ".env" }
 
 [tools]
-rust = "latest"
+rust = { version = "stable", postinstall = "mise exec -- rustup component add clippy rustfmt rust-analyzer" }
 lefthook = "latest"
 
 [hooks.postinstall]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt", "rust-analyzer"]

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -37,7 +37,7 @@ fn start_project_session(name: &str) -> Result<()> {
     project.clone_if_needed()?;
 
     println!("Starting session '{}'...", project.name);
-    SessionBuilder::new(&project).build()?;
+    SessionBuilder::new(&project).start_with_control()?;
     tmux::connect_to_session(&project.name)?;
 
     Ok(())
@@ -66,7 +66,7 @@ fn start_worktree_session(project_name: &str, branch: &str) -> Result<()> {
         .with_session_name(session_name.clone())
         .with_root(worktree.path.to_string_lossy().to_string())
         .with_worktree(branch.to_string())
-        .build()?;
+        .start_with_control()?;
 
     tmux::connect_to_session(&session_name)?;
 

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -28,18 +28,9 @@ pub fn run(project_name: Option<String>) -> Result<()> {
     // Create the session builder
     let builder = SessionBuilder::new(&project);
 
-    // Create session with setup window
+    // Create session, run post-create, then setup windows via control mode
     println!("Starting session '{}'...", project.name);
-    builder.create_session()?;
-
-    // If there are post-create commands, run them first, then setup windows
-    if builder.has_post_create_commands() {
-        // Build the command chain: post-create commands && twig project setup-windows
-        builder.run_post_create_then("twig project setup-windows")?;
-    } else {
-        // No post-create commands, setup windows immediately
-        builder.setup_windows()?;
-    }
+    builder.start_with_control()?;
 
     // Connect to the session
     tmux::connect_to_session(&project.name)?;

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -52,16 +52,8 @@ fn create_and_start(project_name: &str, branch_name: &str) -> Result<()> {
         .with_root(worktree_path.to_string_lossy().to_string())
         .with_worktree(branch_name.to_string());
 
-    // Create session with setup window
-    builder.create_session()?;
-
-    // If there are post-create commands, run them first, then setup windows
-    if builder.has_post_create_commands() {
-        builder.run_post_create_then("twig project setup-windows")?;
-    } else {
-        // No post-create commands, setup windows immediately
-        builder.setup_windows()?;
-    }
+    // Create session, run post-create, then setup windows via control mode
+    builder.start_with_control()?;
 
     tmux::connect_to_session(&session_name)?;
 
@@ -98,7 +90,7 @@ fn start_project_session(name: &str) -> Result<()> {
     project.clone_if_needed()?;
 
     println!("Starting session '{}'...", project.name);
-    SessionBuilder::new(&project).build()?;
+    SessionBuilder::new(&project).start_with_control()?;
     tmux::connect_to_session(&project.name)?;
 
     Ok(())
@@ -127,7 +119,7 @@ fn start_worktree_session(project_name: &str, branch: &str) -> Result<()> {
         .with_session_name(session_name.clone())
         .with_root(worktree.path.to_string_lossy().to_string())
         .with_worktree(branch.to_string())
-        .build()?;
+        .start_with_control()?;
 
     tmux::connect_to_session(&session_name)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ mod ui;
 #[derive(Parser)]
 #[command(name = "twig")]
 #[command(about = "Tmux session manager with git worktree support")]
+#[command(
+    after_long_help = "Debug: set TWIG_DEBUG=1 to enable verbose tmux control output on stderr."
+)]
 #[command(version)]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary
- run session setup through tmux control mode with sequential post-create commands and setup-twig window
- keep tree view open with locked input and spinner until session start completes, then auto-attach
- document TWIG_DEBUG and standardize rust toolchain setup via mise/rust-toolchain.toml