### PR TITLE
ci: add basic lint/test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+        with:
+          cache: true
+
+      - name: Install tools
+        run: |
+          mise install
+          mise use -g tmux@latest
+
+      - name: Lint
+        run: lefthook run ci
+
+      - name: Test
+        run: cargo test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 
 **twig** is a tmux session manager with git worktree support, written in Rust.
 It manages tmux sessions based on YAML project configs, supports git worktrees with
-automatic file copying and post-create commands, and uses Charmbracelet Gum for
-interactive terminal UI.
+automatic file copying and post-create commands, and provides a TUI for interactive
+terminal workflows.
 
 ## Build/Lint/Test Commands
 
@@ -43,18 +43,21 @@ twig/
 │   │   ├── mod.rs
 │   │   ├── delete.rs
 │   │   ├── edit.rs
+│   │   ├── kill.rs
 │   │   ├── list.rs
 │   │   ├── new.rs
 │   │   ├── start.rs
-│   │   ├── stop.rs
+│   │   ├── tree_view.rs
+│   │   ├── window.rs
 │   │   └── worktree.rs
 │   ├── config/             # Configuration types
 │   │   ├── mod.rs
 │   │   ├── global.rs       # GlobalConfig
 │   │   └── project.rs      # Project, Window, Pane types
 │   ├── git.rs              # Git worktree operations
-│   ├── gum.rs              # Charmbracelet Gum wrapper
 │   └── tmux.rs             # Tmux session management
+│   ├── tmux_control.rs      # Low-level tmux control helpers
+│   └── ui.rs                # TUI rendering
 ├── Cargo.toml
 ├── rustfmt.toml            # Max width 100, 4 spaces
 ├── clippy.toml
@@ -194,7 +197,11 @@ mod tests {
 |-------|---------|
 | clap | CLI argument parsing (derive feature) |
 | serde + serde_yaml | YAML config serialization |
+| serde_json | JSON serialization |
 | anyhow | Error handling |
 | shellexpand | Path expansion (~) |
 | dirs | Standard directories |
 | regex + once_cell | Lazy static regex patterns |
+| ratatui + crossterm | Terminal UI rendering |
+| tui-tree-widget | Tree view UI component |
+| fuzzy-matcher | Fuzzy matching for search |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,3 +21,13 @@ pre-push:
     build:
       run: cargo build --release
       fail_text: "Release build failed"
+
+ci:
+  parallel: false
+  commands:
+    fmt:
+      run: cargo fmt -- --check
+      fail_text: "Run 'cargo fmt' to fix formatting"
+    clippy:
+      run: cargo clippy --all-targets --all-features -- -D warnings
+      fail_text: "Fix clippy warnings"


### PR DESCRIPTION
## Summary
- add CI workflow with mise setup, tmux install, lint, and tests
- add lefthook `ci` target for fmt/clippy checks
- refresh AGENTS.md to match current repo layout/deps

## Testing
- lefthook pre-push (cargo test, cargo build --release)