### PR TITLE
Add verbose flag and refresh debug docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig"
-version = "0.2.0"
+version = "0.1.2"
 edition = "2021"
 description = "Tmux session manager with git worktree support"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ twig delete [project]    # Delete project config
 twig stop [project]      # Kill tmux session
 
 # Debug tmux control-mode I/O
-Setting `TWIG_DEBUG=1` enables verbose tmux control output on stderr.
-TWIG_DEBUG=1 twig window new [project] [name]
+Use `--verbose` (or `TWIG_DEBUG=1`) to enable verbose tmux control output on stderr.
+twig --verbose window new [project] [name]
 
 # Run a command in a window/pane
 twig run --project=dotfiles --window=6 --pane=1 -- whoami

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,13 @@ mod ui;
 #[command(name = "twig")]
 #[command(about = "Tmux session manager with git worktree support")]
 #[command(
-    after_long_help = "Debug: set TWIG_DEBUG=1 to enable verbose tmux control output on stderr."
+    after_long_help = "Debug: use --verbose or set TWIG_DEBUG=1 to enable verbose tmux control output on stderr."
 )]
 #[command(version)]
 struct Cli {
+    /// Enable verbose tmux control output (sets TWIG_DEBUG=1)
+    #[arg(long, short, global = true)]
+    verbose: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -173,6 +176,10 @@ enum WindowCommands {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    if cli.verbose {
+        std::env::set_var("TWIG_DEBUG", "1");
+    }
 
     match cli.command {
         Commands::Start { project } => cli::start::run(project),


### PR DESCRIPTION
## Summary
- add global `--verbose`/`-v` flag that maps to `TWIG_DEBUG` for all commands
- refresh README debug instructions to reference the new flag
- adjust crate version metadata in Cargo.toml

## Testing
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check