### PR TITLE
chore(ci): provide crates token to release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,6 +9,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
 jobs:
   release-plz-pr:
     name: Release-plz PR


### PR DESCRIPTION
## Summary
- Expose `CARGO_REGISTRY_TOKEN` at the workflow level so release-plz can publish.