### PR TITLE
chore(release): enable crates.io publish

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,4 +5,3 @@ changelog_path = "CHANGELOG.md"
 name = "twig"
 changelog_path = "CHANGELOG.md"
 git_tag_name = "v{{ version }}"
-publish = false


### PR DESCRIPTION
## Summary
- Allow release-plz to publish to crates.io by removing `publish = false`.